### PR TITLE
Consolidate git AHEAD and BEHIND into DIVERGED

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -290,6 +290,13 @@ function _omz_git_prompt_status() {
     done
   fi
 
+  # Simplify to DIVERGED if both AHEAD and BEHIND
+  if (( ${+statuses_seen[AHEAD]} && ${+statuses_seen[BEHIND]} )); then
+    statuses_seen[DIVERGED]=1
+    unset -v "statuses_seen[AHEAD]"
+    unset -v "statuses_seen[BEHIND]"
+  fi
+
   # For each status prefix, do a regex comparison
   for status_prefix in ${(k)prefix_constant_map}; do
     local status_constant="${prefix_constant_map[$status_prefix]}"


### PR DESCRIPTION
- If a branch is both ahead and behind, we only need to show the diverged status

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
